### PR TITLE
fix!(profile): use crc32 for profile background color calculation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -680,9 +680,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.3.2"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
 dependencies = [
  "cfg-if",
 ]
@@ -1526,6 +1526,7 @@ dependencies = [
  "console_error_panic_hook",
  "console_log",
  "convert_case",
+ "crc32fast",
  "futures",
  "gloo",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ web-time = "1.0.0"
 k256 = { version = "0.13.3", default-features = false, features = ["std"] }
 icondata_core = "0.1.0"
 serde_json = "1.0"
+crc32fast = "1.4.0"
 
 [build-dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/src/utils/profile.rs
+++ b/src/utils/profile.rs
@@ -1,5 +1,3 @@
-use std::array;
-
 use candid::Principal;
 use futures::{Future, Stream, StreamExt};
 use serde::{Deserialize, Serialize};
@@ -43,12 +41,8 @@ impl From<UserProfileDetailsForFrontend> for ProfileDetails {
 }
 
 fn color_from_principal(principal: Principal) -> String {
-    let mut col_iter = principal
-        .as_slice()
-        .chunks(4)
-        .map(|c| c.iter().fold(0u8, |acc, &x| acc.wrapping_add(x)));
-    let colors: [u8; 3] = array::from_fn(|_| col_iter.next().unwrap());
-    hex::encode(colors)
+    let col_int = crc32fast::hash(principal.as_slice()) & 0xFFFFFF;
+    format!("{col_int:06x}")
 }
 
 impl ProfileDetails {


### PR DESCRIPTION
truncates the hash to 28 bits, previous code was written with assumption that user principals are atleast 12 bytes, but its not guaranteed as principals are opaque