### PR TITLE
[REGRESSION] remove list virtualization

### DIFF
--- a/src/page/post_view/mod.rs
+++ b/src/page/post_view/mod.rs
@@ -105,11 +105,15 @@ pub fn ScrollingView<NV: Fn() -> NVR + Clone + 'static, NVR>(
                             recovering_state.set(false);
                         }
                     });
+                    let show_video = create_memo(move |_| queue_idx.abs_diff(current_idx()) <= 20);
+                    let uid = move || details.uid.clone();
                     view! {
                         <div _ref=container_ref class="snap-always snap-end w-full h-full">
-                            <BgView uid=details.uid>
-                                <VideoView idx=queue_idx muted/>
-                            </BgView>
+                            <Show when=show_video>
+                                <BgView uid=uid()>
+                                    <VideoView idx=queue_idx muted/>
+                                </BgView>
+                            </Show>
                         </div>
                     }
                 }

--- a/src/page/post_view/video_loader.rs
+++ b/src/page/post_view/video_loader.rs
@@ -60,26 +60,20 @@ pub fn VideoView(idx: usize, muted: RwSignal<bool>) -> impl IntoView {
         vid.set_loop(true);
         Some(())
     });
-    let show_video = create_memo(move |_| idx.abs_diff(current_idx()) <= 20);
 
     view! {
-        <Show
-            when=show_video
-            fallback=|| view! { <div class="bg-black h-dvh max-h-dvh absolute z-[3] w-2/12"></div> }
-        >
-            <video
-                on:click=move |_| muted.update(|m| *m = !*m)
-                _ref=container_ref
-                class="object-contain absolute z-[3] h-dvh max-h-dvh cursor-pointer"
-                poster=view_bg_url
-                src=view_video_url
-                loop
-                muted
-                playsinline
-                disablepictureinpicture
-                disableremoteplayback
-                preload="auto"
-            ></video>
-        </Show>
+        <video
+            on:click=move |_| muted.update(|m| *m = !*m)
+            _ref=container_ref
+            class="object-contain absolute z-[3] h-dvh max-h-dvh cursor-pointer"
+            poster=view_bg_url
+            src=view_video_url
+            loop
+            muted
+            playsinline
+            disablepictureinpicture
+            disableremoteplayback
+            preload="auto"
+        ></video>
     }
 }


### PR DESCRIPTION
partially fixes https://github.com/go-bazzinga/hot-or-not-web-leptos-ssr/issues/65
(Weird stuttering on ios is still present, possible fix is in investigation)

To mitigate this effective memory leak, we're hiding video elements which are way up in the view
per rough calculations, each element is consuming ~120 KiB on firefox linux
to saturate the memory usage to ~500 MiB the user would have to scroll roughly more than 4200 times