### PR TITLE
Fix: fix buggy overlay experience

### DIFF
--- a/ssr/src/page/post_view/mod.rs
+++ b/ssr/src/page/post_view/mod.rs
@@ -176,7 +176,7 @@ pub fn PostViewWithUpdates(initial_post: Option<PostDetails>) -> impl IntoView {
         video_queue.update_untracked(|v| {
             if v.len() > 1 {
                 // Safe to do a GC here
-                let rem = 0..(current_idx.get_untracked().saturating_sub(3));
+                let rem = 0..(current_idx.get_untracked().saturating_sub(5));
                 current_idx.update(|c| *c -= rem.len());
                 v.drain(rem);
                 return;

--- a/ssr/src/page/post_view/mod.rs
+++ b/ssr/src/page/post_view/mod.rs
@@ -176,7 +176,7 @@ pub fn PostViewWithUpdates(initial_post: Option<PostDetails>) -> impl IntoView {
         video_queue.update_untracked(|v| {
             if v.len() > 1 {
                 // Safe to do a GC here
-                let rem = 0..(current_idx.get_untracked().saturating_sub(5));
+                let rem = 0..(current_idx.get_untracked().saturating_sub(6));
                 current_idx.update(|c| *c -= rem.len());
                 v.drain(rem);
                 return;

--- a/ssr/src/page/post_view/video_loader.rs
+++ b/ssr/src/page/post_view/video_loader.rs
@@ -35,8 +35,10 @@ pub fn BgView(
     let (referrer_store, _, _) = use_referrer_store();
 
     create_effect(move |_| {
-        if current_idx.get() == 5 {
+        if current_idx.get() % 4 != 0 {
             set_show_login_popup.update(|n| *n = false);
+        } else {
+            set_show_login_popup.update(|n| *n = true);
         }
         Some(())
     });
@@ -48,7 +50,7 @@ pub fn BgView(
                 style:background-color="rgb(0, 0, 0)"
                 style:background-image=move || format!("url({})", bg_url(uid()))
             ></div>
-            <Show when=move || { idx == 4 && !is_connected.get() && show_login_popup.get() }>
+            <Show when=move || { current_idx.get() != 0 && current_idx.get() % 4 == 0 && !is_connected.get() && show_login_popup.get() }>
                 <FeedPopUp
                     on_click=move |_| set_show_login_popup.set(false)
                     header_text="Your 1000 COYNs

--- a/ssr/src/page/post_view/video_loader.rs
+++ b/ssr/src/page/post_view/video_loader.rs
@@ -35,7 +35,7 @@ pub fn BgView(
     let (referrer_store, _, _) = use_referrer_store();
 
     create_effect(move |_| {
-        if current_idx.get() % 4 != 0 {
+        if current_idx.get() % 5 != 0 {
             set_show_login_popup.update(|n| *n = false);
         } else {
             set_show_login_popup.update(|n| *n = true);
@@ -50,7 +50,7 @@ pub fn BgView(
                 style:background-color="rgb(0, 0, 0)"
                 style:background-image=move || format!("url({})", bg_url(uid()))
             ></div>
-            <Show when=move || { current_idx.get() != 0 && current_idx.get() % 4 == 0 && !is_connected.get() && show_login_popup.get() }>
+            <Show when=move || { current_idx.get() != 0 && current_idx.get() % 5 == 0 && !is_connected.get() && show_login_popup.get() }>
                 <FeedPopUp
                     on_click=move |_| set_show_login_popup.set(false)
                     header_text="Your 1000 COYNs


### PR DESCRIPTION
- pop-up login after every 4 scrolls for non-logged-in user
- When user navigate back to the home page from any other page, pop-up first login after 3 scrolls and then after every 4 scrolls
Closes: #283 