### PR TITLE
error event value

### DIFF
--- a/ssr/src/page/err.rs
+++ b/ssr/src/page/err.rs
@@ -27,8 +27,13 @@ pub fn ServerErrorPage() -> impl IntoView {
             .unwrap_or_else(|_| "Server Error".to_string())
     });
 
+    let error_str = params
+        .get()
+        .map(|p| p.err.clone())
+        .unwrap_or_else(|_| "Server Error".to_string());
+
     let canister_store = auth_canisters_store();
-    ErrorEvent.send_event(error, canister_store);
+    ErrorEvent.send_event(error_str, canister_store);
 
     view! { <ErrorView error/> }
 }

--- a/ssr/src/utils/event_streaming/events.rs
+++ b/ssr/src/utils/event_streaming/events.rs
@@ -1,6 +1,6 @@
 use ic_agent::Identity;
 use leptos::html::Input;
-use leptos::{create_effect, ReadSignal, RwSignal, Signal, SignalGetUntracked};
+use leptos::{create_effect, ReadSignal, RwSignal, SignalGetUntracked};
 use leptos::{create_signal, ev, expect_context, html::Video, Memo, NodeRef, SignalGet, SignalSet};
 use leptos_use::use_event_listener;
 use serde_json::json;

--- a/ssr/src/utils/event_streaming/events.rs
+++ b/ssr/src/utils/event_streaming/events.rs
@@ -677,7 +677,7 @@ impl LogoutConfirmation {
 pub struct ErrorEvent;
 
 impl ErrorEvent {
-    pub fn send_event(&self, error: Signal<String>, cans_store: RwSignal<Option<Canisters<true>>>) {
+    pub fn send_event(&self, error_str: String, cans_store: RwSignal<Option<Canisters<true>>>) {
         #[cfg(all(feature = "hydrate", feature = "ga4"))]
         {
             let event_history: EventHistory = expect_context();
@@ -693,7 +693,7 @@ impl ErrorEvent {
                 &json!({
                     "user_id": user_id,
                     "canister_id": canister_id,
-                    "description": error.get_untracked(),
+                    "description": error_str,
                     "previous_event": event_history.event_name.get_untracked(),
                 }),
             );


### PR DESCRIPTION
Events are getting the default string "Coffee break" on error event which is not useful for the type of error tracking in Bigquery/GA4. This PR fixes it