### PR TITLE
remove using random subnet as temp fix

### DIFF
--- a/ssr/src/state/canisters.rs
+++ b/ssr/src/state/canisters.rs
@@ -209,6 +209,7 @@ impl<const A: bool> Canisters<A> {
         SnsRoot(canister_id, agent)
     }
 
+    #[allow(dead_code)]
     async fn subnet_indexes(&self) -> Result<Vec<Principal>, AgentError> {
         #[cfg(any(feature = "local-bin", feature = "local-lib"))]
         {
@@ -239,7 +240,7 @@ pub fn unauth_canisters() -> Canisters<false> {
 async fn create_individual_canister(
     canisters: &Canisters<true>,
 ) -> Result<Principal, ServerFnError> {
-    let subnet_idxs = canisters.subnet_indexes().await?;
+    // let subnet_idxs = canisters.subnet_indexes().await?;
 
     let mut by = [0u8; 16];
     let principal = canisters.identity().sender().unwrap();
@@ -247,8 +248,9 @@ async fn create_individual_canister(
     let cnt = by.len().min(principal_by.len());
     by[..cnt].copy_from_slice(&principal_by[..cnt]);
 
-    let discrim = u128::from_be_bytes(by);
-    let subnet_idx = subnet_idxs[(discrim % subnet_idxs.len() as u128) as usize];
+    // let discrim = u128::from_be_bytes(by);
+    // let subnet_idx = subnet_idxs[(discrim % subnet_idxs.len() as u128) as usize];
+    let subnet_idx = Principal::from_text("znhy2-2qaaa-aaaag-acofq-cai").unwrap();
     let idx = canisters.user_index_with(subnet_idx).await;
     let user_canister = idx
         .get_requester_principals_canister_id_create_if_not_exists_and_optionally_allow_referrer()


### PR DESCRIPTION
## Changes
- use const subnet id for new canisters as temporary fix

