### PR TITLE
fix: show send button conditionally on token info page

### DIFF
--- a/ssr/src/page/token/info.rs
+++ b/ssr/src/page/token/info.rs
@@ -4,7 +4,10 @@ use leptos_icons::*;
 use leptos_router::*;
 
 use crate::{
-    component::{back_btn::BackButton, bullet_loader::BulletLoader, canisters_prov::AuthCansProvider, spinner::FullScreenSpinner, title::Title},
+    component::{
+        back_btn::BackButton, bullet_loader::BulletLoader, canisters_prov::AuthCansProvider,
+        spinner::FullScreenSpinner, title::Title,
+    },
     page::token::TokenInfoParams,
     state::canisters::unauth_canisters,
     utils::token::{token_metadata_by_root, TokenMetadata},
@@ -36,7 +39,7 @@ fn TokenDetails(meta: TokenMetadata) -> impl IntoView {
 fn TokenInfoInner(
     root: Principal,
     user_principal: Principal,
-    meta: TokenMetadata
+    meta: TokenMetadata,
 ) -> impl IntoView {
     let meta_c = meta.clone();
     let detail_toggle = create_rw_signal(false);

--- a/ssr/src/page/token/info.rs
+++ b/ssr/src/page/token/info.rs
@@ -1,9 +1,10 @@
+use candid::Principal;
 use leptos::*;
 use leptos_icons::*;
 use leptos_router::*;
 
 use crate::{
-    component::{back_btn::BackButton, spinner::FullScreenSpinner, title::Title},
+    component::{back_btn::BackButton, bullet_loader::BulletLoader, canisters_prov::AuthCansProvider, spinner::FullScreenSpinner, title::Title},
     page::token::TokenInfoParams,
     state::canisters::unauth_canisters,
     utils::token::{token_metadata_by_root, TokenMetadata},
@@ -32,7 +33,11 @@ fn TokenDetails(meta: TokenMetadata) -> impl IntoView {
 }
 
 #[component]
-fn TokenInfoInner(meta: TokenMetadata) -> impl IntoView {
+fn TokenInfoInner(
+    root: Principal,
+    user_principal: Principal,
+    meta: TokenMetadata
+) -> impl IntoView {
     let meta_c = meta.clone();
     let detail_toggle = create_rw_signal(false);
     let view_detail_icon = Signal::derive(move || {
@@ -94,6 +99,18 @@ fn TokenInfoInner(meta: TokenMetadata) -> impl IntoView {
                         <TokenDetails meta=meta_c.clone() />
                     </Show>
                 </div>
+                <AuthCansProvider fallback=BulletLoader let:canisters>
+                    <Show when=move || {
+                        user_principal == canisters.profile_details().principal
+                    }>
+                        <a
+                            href=format!("/token/transfer/{root}")
+                            class="flex flex-row justify-self-center justify-center text-white md:text-lg w-full md:w-1/2 rounded-full p-3 bg-primary-600"
+                        >
+                            Send
+                        </a>
+                    </Show>
+                </AuthCansProvider>
             </div>
         </div>
     }
@@ -109,7 +126,7 @@ pub fn TokenInfo() -> impl IntoView {
         };
         let cans = unauth_canisters();
         let meta = token_metadata_by_root(&cans, params.user_principal, params.token_root).await?;
-        Ok(meta)
+        Ok(meta.map(|m| (m, (params.token_root, params.user_principal))))
     });
 
     view! {
@@ -119,7 +136,7 @@ pub fn TokenInfo() -> impl IntoView {
                     .and_then(|info| info.ok())
                     .map(|info| {
                         match info {
-                            Some(metadata) => view! { <TokenInfoInner meta=metadata /> },
+                            Some((metadata,(root,user_principal))) => view! { <TokenInfoInner root user_principal meta=metadata /> },
                             None => view! { <Redirect path="/" /> },
                         }
                     })

--- a/ssr/src/page/wallet/tokens.rs
+++ b/ssr/src/page/wallet/tokens.rs
@@ -102,7 +102,7 @@ pub fn TokenView(
                 info.map(|info| {
                     view! {
                         <a
-                            href=format!("/token/info/{token_root}")
+                            href=format!("/token/info/{token_root}/{user_principal}")
                             _ref=_ref
                             class="grid grid-cols-2 grid-rows-1 w-full items-center p-4 rounded-xl border-2 border-neutral-700 bg-white/15"
                         >


### PR DESCRIPTION
- Show send button on /token/info page only for the native profile and not for other profile user
- Fixed navigation to /token/info page from wallet page