### PR TITLE
fix: enable token transfer to non-yral principal

### DIFF
--- a/ssr/src/page/token/transfer.rs
+++ b/ssr/src/page/token/transfer.rs
@@ -28,7 +28,6 @@ use super::{popups::TokenTransferPopup, TokenParams};
 )]
 async fn transfer_token_to_user_principal(
     cans_wire: CanistersAuthWire,
-    destination_canister_principal: Option<Principal>,
     destination_principal: Principal,
     ledger_canister: Principal,
     root_canister: Principal,
@@ -86,6 +85,11 @@ async fn transfer_token_to_user_principal(
     //     .unwrap();
     // let transfer_result: types::TransferResult = Decode!(&res, types::TransferResult).unwrap();
     // println!("transfer_result: {:?}", transfer_result);
+
+    let destination_canister_principal = cans
+        .get_individual_canister_by_user_principal(destination_principal)
+        .await
+        .unwrap();
 
     if let Some(destination_canister_principal) = destination_canister_principal {
         let destination_canister = cans.individual_user(destination_canister_principal).await;
@@ -200,10 +204,7 @@ fn TokenTransferInner(
         let auth_cans_wire = auth_cans_wire.clone();
         async move {
             let destination = destination_res.get_untracked().unwrap().unwrap();
-            let destination_canister = cans
-                .get_individual_canister_by_user_principal(destination)
-                .await
-                .unwrap();
+
             // let amt = amt_res.get_untracked().unwrap().unwrap();
 
             // let user = cans.authenticated_user().await;
@@ -228,7 +229,6 @@ fn TokenTransferInner(
 
             transfer_token_to_user_principal(
                 auth_cans_wire.wait_untracked().await.unwrap(),
-                destination_canister,
                 destination,
                 ledger_canister,
                 root,

--- a/ssr/src/page/token/transfer.rs
+++ b/ssr/src/page/token/transfer.rs
@@ -88,12 +88,11 @@ async fn transfer_token_to_user_principal(
 
     let destination_canister_principal = cans
         .get_individual_canister_by_user_principal(destination_principal)
-        .await
-        .unwrap();
+        .await?;
 
     if let Some(destination_canister_principal) = destination_canister_principal {
         let destination_canister = cans.individual_user(destination_canister_principal).await;
-        let res = destination_canister.add_token(root_canister).await.unwrap();
+        let res = destination_canister.add_token(root_canister).await?;
         println!("add_token res: {:?}", res);
     }
 

--- a/ssr/src/page/token/transfer.rs
+++ b/ssr/src/page/token/transfer.rs
@@ -14,7 +14,7 @@ use crate::{
         web::{copy_to_clipboard, paste_from_clipboard},
     },
 };
-use candid::{Nat, Principal};
+use candid::Principal;
 use leptos::*;
 use leptos_icons::*;
 use leptos_router::*;
@@ -28,7 +28,7 @@ use super::{popups::TokenTransferPopup, TokenParams};
 )]
 async fn transfer_token_to_user_principal(
     cans_wire: CanistersAuthWire,
-    destination_canister: Principal,
+    destination_canister_principal: Option<Principal>,
     destination_principal: Principal,
     ledger_canister: Principal,
     root_canister: Principal,
@@ -49,21 +49,6 @@ async fn transfer_token_to_user_principal(
             from_subaccount: None,
             to: Account {
                 owner: destination_principal,
-                subaccount: None,
-            },
-            created_at_time: None,
-        })
-        .await
-        .unwrap();
-    log::debug!("transfer res: {:?}", res);
-    let res = sns_ledger
-        .icrc_1_transfer(TransferArg {
-            memo: Some(serde_bytes::ByteBuf::from(vec![1])),
-            amount: Nat::from(1_u64),
-            fee: None,
-            from_subaccount: None,
-            to: Account {
-                owner: destination_canister,
                 subaccount: None,
             },
             created_at_time: None,
@@ -102,9 +87,11 @@ async fn transfer_token_to_user_principal(
     // let transfer_result: types::TransferResult = Decode!(&res, types::TransferResult).unwrap();
     // println!("transfer_result: {:?}", transfer_result);
 
-    let destination_canister = cans.individual_user(destination_canister).await;
-    let res = destination_canister.add_token(root_canister).await.unwrap();
-    println!("add_token res: {:?}", res);
+    if let Some(destination_canister_principal) = destination_canister_principal {
+        let destination_canister = cans.individual_user(destination_canister_principal).await;
+        let res = destination_canister.add_token(root_canister).await.unwrap();
+        println!("add_token res: {:?}", res);
+    }
 
     // let res = agent
     //     .update(
@@ -216,7 +203,6 @@ fn TokenTransferInner(
             let destination_canister = cans
                 .get_individual_canister_by_user_principal(destination)
                 .await
-                .unwrap()
                 .unwrap();
             // let amt = amt_res.get_untracked().unwrap().unwrap();
 


### PR DESCRIPTION
Closes: #464 
- Remove 1 token transfer( 1e8 in decimals) to destination canister
- Add token root in destination user canister during transfer only if destination user principal has an allocated canister   