### PR TITLE
add separate job to destroy fly preview apps

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -14,15 +14,15 @@ jobs:
       publish-artifact: true
 
   destroy_preview:
-  if: ${{github.event.pull_request.state == 'closed'}}
-  environment:
-    name: pr-${{ github.event.number }}
-    url: ${{ steps.deploy.outputs.url }}
+    if: ${{github.event.pull_request.state == 'closed'}}
+    environment:
+      name: pr-${{ github.event.number }}
+      url: ${{ steps.deploy.outputs.url }}
 
-  steps:
-    - name: Deploy
-      id: destroy
-      uses: superfly/fly-pr-review-apps@1.2.1
+    steps:
+      - name: Deploy
+        id: destroy
+        uses: superfly/fly-pr-review-apps@1.2.1
 
   preview:
     if: ${{ github.event.pull_request.state == 'open'}}

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -13,8 +13,19 @@ jobs:
     with:
       publish-artifact: true
 
+  destroy_preview:
+  if: ${{github.event.pull_request.state == 'closed'}}
+  environment:
+    name: pr-${{ github.event.number }}
+    url: ${{ steps.deploy.outputs.url }}
+
+  steps:
+    - name: Deploy
+      id: destroy
+      uses: superfly/fly-pr-review-apps@1.2.1
+
   preview:
-    if: ${{ github.event.pull_request.merged == false}}
+    if: ${{ github.event.pull_request.state == 'open'}}
     needs: build_check
     runs-on: ubuntu-latest
 
@@ -32,7 +43,6 @@ jobs:
       - uses: actions/checkout@v3
       - name: Download build
         uses: actions/download-artifact@v4
-        if: ${{ github.event.pull_request.state == 'open'}}
         with:
           name: build-musl
       - run: chmod +x target/x86_64-unknown-linux-musl/release/hot-or-not-web-leptos-ssr
@@ -43,7 +53,6 @@ jobs:
 
       - uses: superfly/flyctl-actions/setup-flyctl@master
       - name: Set secret tokens
-        if: ${{ github.event.pull_request.state == 'open'}}
         run: |
           APP_NAME="pr-${{github.event.number}}-yral-dapp-hot-or-not-web-leptos-ssr"
           flyctl secrets set CF_TOKEN="$CF_TOKEN" --app "$APP_NAME" --stage

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -15,6 +15,7 @@ jobs:
 
   destroy_preview:
     if: ${{github.event.pull_request.state == 'closed'}}
+    runs-on: ubuntu-latest
     environment:
       name: pr-${{ github.event.number }}
       url: ${{ steps.deploy.outputs.url }}


### PR DESCRIPTION
## Changes
- We cannot add if conditional on `needs` workflow. Adding a separate job to destrory the preview app.