### PR TITLE
Fixed: Wait for Upload in `/upload`

### DIFF
--- a/ssr/src/page/src/upload/mod.rs
+++ b/ssr/src/page/src/upload/mod.rs
@@ -32,6 +32,7 @@ struct UploadParams {
 fn PreUploadView(
     trigger_upload: WriteSignal<Option<UploadParams>, LocalStorage>,
     uid: RwSignal<Option<String>, LocalStorage>,
+    publish_clicked: WriteSignal<bool, LocalStorage>,
 ) -> impl IntoView {
     let description_err = RwSignal::new(String::new());
     let desc_err_memo = Memo::new(move |_| description_err());
@@ -81,6 +82,7 @@ fn PreUploadView(
                 .map(|v| v.checked())
                 .unwrap_or_default(),
         }));
+        publish_clicked.set(true);
     };
 
     let hashtag_on_input = move |hts| match hashtags_validator(hts) {
@@ -171,6 +173,7 @@ pub fn CreatorDaoCreatePage() -> impl IntoView {
 pub fn YralUploadPostPage() -> impl IntoView {
     let trigger_upload = RwSignal::new_local(None::<UploadParams>);
     let uid = RwSignal::new_local(None);
+    let publish_clicked = RwSignal::new_local(false);
 
     view! {
         <Title text="YRAL - Upload" />
@@ -179,11 +182,11 @@ pub fn YralUploadPostPage() -> impl IntoView {
                 <Show
                     when=move || { trigger_upload.with(| trigger_upload | trigger_upload.is_some()) }
                     fallback=move || {
-                        view! { <PreUploadView trigger_upload=trigger_upload.write_only() uid=uid /> }
+                        view! { <PreUploadView trigger_upload=trigger_upload.write_only() uid=uid publish_clicked=publish_clicked.write_only()/> }
                     }
                 >
 
-                    <VideoUploader params=trigger_upload.get_untracked().unwrap() uid=uid />
+                    <VideoUploader params=trigger_upload.get_untracked().unwrap() uid=uid publish_clicked=publish_clicked/>
                 </Show>
             </div>
         </div>

--- a/ssr/src/page/src/upload/video_upload.rs
+++ b/ssr/src/page/src/upload/video_upload.rs
@@ -352,7 +352,7 @@ pub fn VideoUploader(
         let current_uid = uid.get();
         let publish_now = publish_clicked.get();
 
-        if publish_now && current_uid.is_some() && prev_uid.map_or(true, |puid| puid.is_none()) {
+        if publish_now && current_uid.is_some() && prev_uid.is_none_or(|puid| puid.is_none()) {
             log::info!("Dispatching publish action");
             publish_clicked.set(false);
 


### PR DESCRIPTION
- Introduced a new `publish_clicked` signal to track the publish action state.
- Updated `PreUploadView` and `VideoUploader` components to utilize the new signal.
- Modified the upload action to set the `uid` based on the upload response.
- Implemented logic to dispatch the publish action when the video is uploaded and the publish button is clicked.
- Cleaned up the video upload UI for better user experience.