### PR TITLE
Compare mixpanel events

### DIFF
--- a/ssr/src/utils/src/mixpanel/mixpanel_events.rs
+++ b/ssr/src/utils/src/mixpanel/mixpanel_events.rs
@@ -50,6 +50,10 @@ pub fn track_event<T>(event_name: &str, props: T)
 where
     T: Serialize,
 {
+    let track_props = serde_wasm_bindgen::to_value(&props);
+    if let Ok(track_props) = track_props {
+        let _ = track(event_name, track_props);
+    }
     let mut props = serde_json::to_value(&props).unwrap();
     props["event"] = event_name.into();
     let user_id = props.get("user_id").and_then(Value::as_str);
@@ -58,8 +62,7 @@ where
     } else {
         props.get("visitor_id").and_then(Value::as_str).into()
     };
-    let track_props = JsValue::from_str(serde_json::to_string(&props).unwrap().as_str());
-    let _ = track(event_name, track_props);
+
     spawn_local(async {
         let res = track_event_server_fn(props).await;
         match res {

--- a/ssr/src/utils/src/mixpanel/mixpanel_events.rs
+++ b/ssr/src/utils/src/mixpanel/mixpanel_events.rs
@@ -58,6 +58,8 @@ where
     } else {
         props.get("visitor_id").and_then(Value::as_str).into()
     };
+    let track_props = JsValue::from_str(serde_json::to_string(&props).unwrap().as_str());
+    let _ = track(event_name, track_props);
     spawn_local(async {
         let res = track_event_server_fn(props).await;
         match res {


### PR DESCRIPTION
To compare mixpanel events for client side sdk vs server side impl. 
Client side events are going to the [Gobazzinga project](https://mixpanel.com/project/3662504/view/4161240/app/events) and [server side](https://mixpanel.com/project/3717000/view/4215008/app/events) are going to testing project.

closes https://github.com/dolr-ai/product-roadmap/issues/531